### PR TITLE
fix: flipBottom animation translateZ for IOS

### DIFF
--- a/src/FlipCountdown.vue
+++ b/src/FlipCountdown.vue
@@ -411,7 +411,7 @@ export default {
     0%,
     50% {
         z-index: -1;
-        transform: rotateX(90deg);
+        transform: rotateX(90deg) translateZ(0px);
         opacity: 0;
     }
 
@@ -421,7 +421,7 @@ export default {
 
     100% {
         opacity: 1;
-        transform: rotateX(0deg);
+        transform: rotateX(0deg) translateZ(1px);
         z-index: 5;
     }
 }


### PR DESCRIPTION
Add translateZ to animation filpBottom, because on IOS z-index cover is not complete